### PR TITLE
use lodash memoize, instead of implementing a cache

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -5,6 +5,7 @@ import denodeify from 'denodeify';
 import path from 'path';
 import 'traceur/bin/traceur-runtime';
 import { retry } from 'asyncbox';
+import _ from 'lodash';
 
 const exec = support.core.exec;
 const util = support.util;
@@ -18,8 +19,6 @@ const DEFAULT_NUMBER_OF_RETRIES = 3;
 
 const log = process.env.GLOBAL_NPMLOG ? global.log : npmlog;
 
-// we cache some values returned by the functions in this module, because running full `exec` functions are costly, and these functions a utilities used often
-let cache = {};
 
 function hasExpectedSubDir (path) {
   return path.substring(path.length - XCODE_SUBDIR.length) === XCODE_SUBDIR;
@@ -80,21 +79,17 @@ async function getPathFromXcodeSelect () {
   }
 }
 
-function getPath () {
-  // cached function
-  if (cache.path) { return cache.path; }
+const getPath = _.memoize(function () {
 
   // first we try using xcode-select to find the path
   // then we try using the symlinks that Apple has by default
 
-  cache.path = getPathFromXcodeSelect().catch(getPathFromSymlink);
+  return getPathFromXcodeSelect().catch(getPathFromSymlink);
+});
 
-  return cache.path;
-}
+
 
 async function getVersionWithoutRetry () {
-  // cached function
-  if (cache.version) { return cache.version; }
 
   let xcodePath = await getPath();
 
@@ -116,13 +111,15 @@ async function getVersionWithoutRetry () {
     throw new Error(`Could not parse Xcode version. xcodebuild output was: ${stdout}`);
   }
 
-  cache.version = match[0];
-  return cache.version;
+  return match[0];
 }
 
-async function getVersion () {
-  return retry(3, getVersionWithoutRetry);
-}
+
+const getVersion = _.memoize(
+  async function (retries = DEFAULT_NUMBER_OF_RETRIES) {
+    return retry(retries, getVersionWithoutRetry);
+  }
+);
 
 async function getAutomationTraceTemplatePathWithoutRetry () {
 
@@ -153,15 +150,15 @@ async function getAutomationTraceTemplatePathWithoutRetry () {
 
 }
 
-async function getAutomationTraceTemplatePath (retries = DEFAULT_NUMBER_OF_RETRIES) {
-  return retry(retries, getAutomationTraceTemplatePathWithoutRetry);
-}
+const getAutomationTraceTemplatePath = _.memoize(
+  async function (retries = DEFAULT_NUMBER_OF_RETRIES) {
+    return retry(retries, getAutomationTraceTemplatePathWithoutRetry);
+  }
+);
 
 // TODO remove this function. should really just be using 'getVersion()' everywhere.
 // This was added for tech-debt backwards compatibility
 async function getMaxIOSSDKWithoutRetry () {
-  // cached function
-  if (cache.sdkVersion) { return cache.sdkVersion; }
 
   const version = await getVersion();
 
@@ -179,13 +176,14 @@ async function getMaxIOSSDKWithoutRetry () {
     throw new Error(`xcrun returned a non-numeric iOS SDK version: ${sdkVersion}`);
   }
 
-  cache.sdkVersion = sdkVersion;
-  return cache.sdkVersion;
+  return sdkVersion;
 }
 
-async function getMaxIOSSDK (retries = DEFAULT_NUMBER_OF_RETRIES) {
-  return retry(retries, getMaxIOSSDKWithoutRetry);
-}
+const getMaxIOSSDK = _.memoize(
+  function (retries = DEFAULT_NUMBER_OF_RETRIES) {
+    return retry(retries, getMaxIOSSDKWithoutRetry);
+  }
+);
 
 export { getPath, getVersion, getAutomationTraceTemplatePath, getMaxIOSSDK,
          getAutomationTraceTemplatePathWithoutRetry, getMaxIOSSDKWithoutRetry };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chai": "^2.1.2",
     "chai-as-promised": "^4.3.0",
     "denodeify": "^1.2.1",
+    "lodash": "^3.6.0",
     "npmlog": "^1.2.0",
     "q": "^1.2.0"
   },


### PR DESCRIPTION
Here we're using lodash's memoize instead of the cache I implemented manually.

Does the way I used the `_.memoize` function in the function declaration ok with everybody? @sebv 

I'll have to merge this with #3 but just checking if the way I did it is ok.
