### PR TITLE
Add method to parse version data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,19 @@
-language: node_js
-node_js:
-  - "0.12"
+language:
+  - objective-c
+
+before_install:
+
+install:
+  - rm -rf ~/.nvm
+  - git clone https://github.com/creationix/nvm.git ~/.nvm
+  - source ~/.nvm/nvm.sh
+  - nvm install 0.12
+  - node --version
+  - npm install
+  - npm install -g gulp
+
+script:
+  - gulp once
+
 after_success:
     - gulp coveralls

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-// This file should read:
-// export * from 'lib/xcode.js'
+// transpile:main
 
-// but this syntax is broken in traceur: https://github.com/google/traceur-compiler/issues/1042
+export * from 'lib/xcode';

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -1,23 +1,22 @@
-import npmlog from 'npmlog';
-import support from 'appium-support';
-import fs from 'fs';
-import denodeify from 'denodeify';
+import { getLogger } from 'appium-logger';
+import { util, fs } from 'appium-support';
 import path from 'path';
 import { retry } from 'asyncbox';
 import _ from 'lodash';
 import plist from 'plist';
 import { exec } from 'teen_process';
+import bplistParser from 'bplist-parser';
+import B from 'bluebird';
 
-const util = support.util;
-const fileExists = support.util.fileExists;
-const readSymlink = denodeify(fs.readlink);
+let parseFile = B.promisify(bplistParser.parseFile);
+
 const env = process.env;
 
 const XCODE_SELECT_TIMEOUT = 3000;
 const XCODE_SUBDIR = "/Contents/Developer";
 const DEFAULT_NUMBER_OF_RETRIES = 3;
 
-const log = process.env.GLOBAL_NPMLOG ? global.log : npmlog;
+const log = getLogger('Xcode');
 
 
 function hasExpectedSubDir (path) {
@@ -43,7 +42,7 @@ async function getPathFromSymlink (failMessage) {
                                          env.DEVELOPER_DIR  :
                                          env.DEVELOPER_DIR + XCODE_SUBDIR;
 
-    if (await fileExists(customPath)) {
+    if (await fs.exists(customPath)) {
       xcodePath = customPath;
     } else {
       let mesg = `Could not find path to Xcode, environment variable ` +
@@ -52,10 +51,10 @@ async function getPathFromSymlink (failMessage) {
       log.warn(mesg);
       throw new Error(mesg);
     }
-  } else if (await fileExists(symlinkPath)) {
-    xcodePath = readSymlink(symlinkPath);
-  } else if (await fileExists(legacySymlinkPath)) {
-    xcodePath = readSymlink(legacySymlinkPath);
+  } else if (await fs.exists(symlinkPath)) {
+    xcodePath = await fs.readlink(symlinkPath);
+  } else if (await fs.exists(legacySymlinkPath)) {
+    xcodePath = await fs.readlink(legacySymlinkPath);
   }
 
   if (xcodePath) {
@@ -73,17 +72,16 @@ async function getPathFromSymlink (failMessage) {
 }
 
 async function getPathFromXcodeSelect () {
-
   let {stdout} = await exec('xcode-select', ['--print-path'], {timeout: XCODE_SELECT_TIMEOUT});
 
   // trim and remove trailing slash
-  const xcodeFolderPath = stdout.replace(new RegExp("/$"), "").trim();
+  const xcodeFolderPath = stdout.replace(/\/$/, '').trim();
 
   if (!util.hasContent(xcodeFolderPath)) {
     throw new Error("xcode-select returned an empty string");
   }
 
-  if (await fileExists(xcodeFolderPath)) {
+  if (await fs.exists(xcodeFolderPath)) {
     return xcodeFolderPath;
   } else {
     const msg = `xcode-select could not find xcode. Path: ${xcodeFolderPath} does not exist.`;
@@ -103,37 +101,52 @@ const getPath = _.memoize(function () {
 
 
 async function getVersionWithoutRetry () {
-
   let xcodePath = await getPath();
 
   // we want to read the CFBundleShortVersionString from Xcode's plist.
   // It should be in /[root]/XCode.app/Contents/
   const plistPath = path.resolve(xcodePath, "..", "Info.plist");
 
-  if (!await fileExists(plistPath)) {
+  if (!await fs.exists(plistPath)) {
     throw new Error(`Could not get Xcode version. ${plistPath} does not exist on disk.`);
   }
 
-  const cmd = `/usr/libexec/PlistBuddy`;
-  const args =  ['-c', 'Print CFBundleShortVersionString', plistPath];
-  let {stdout} = await exec(cmd, args, {timeout: XCODE_SELECT_TIMEOUT});
+  let version = await parseFile(plistPath);
+  version = version[0].CFBundleShortVersionString;
 
   let versionPattern = /\d\.\d\.*\d*/;
   // need to use string#match here; previous code used regexp#exec, which does not return null
-  let match = stdout.match(versionPattern);
+  let match = version.match(versionPattern);
   if (match === null || !util.hasContent(match[0])) {
-    throw new Error(`Could not parse Xcode version. xcodebuild output was: ${stdout}`);
+    throw new Error(`Could not parse Xcode version. xcodebuild output was: ${version}`);
   }
 
   return match[0];
 }
 
-
-const getVersion = _.memoize(
+const getVersionMemorized = _.memoize(
   function (retries = DEFAULT_NUMBER_OF_RETRIES) {
     return retry(retries, getVersionWithoutRetry);
   }
 );
+
+async function getVersion (parse = false, retries = DEFAULT_NUMBER_OF_RETRIES) {
+  let version = await getVersionMemorized(retries);
+  if (!parse) {
+    return version;
+  }
+  let match = /^(\d+)\.(\d+)(\.(\d+))?$/.exec(version);
+  // match should be an array, either of
+  //     [ '7.0', '7', '0', undefined, undefined, index: 0, input: '7.0' ]
+  //     [ '7.0.1', '7', '0', '.1', '1', index: 0, input: '7.0.1' ]
+  return {
+    versionString: version,
+    versionFloat: parseFloat(`${match[1]}.${match[2]}`),
+    major: parseInt(match[1]),
+    minor: parseInt(match[2]),
+    patch: match[4] ? parseInt(match[4]) : undefined
+  };
+}
 
 async function getAutomationTraceTemplatePathWithoutRetry () {
 
@@ -149,11 +162,11 @@ async function getAutomationTraceTemplatePathWithoutRetry () {
     path.resolve(pathPrefix, "AutomationInstrument." + extensions[1], pathSuffix)
   ];
 
-  if (await fileExists(automationTraceTemplatePaths[0])) {
+  if (await fs.exists(automationTraceTemplatePaths[0])) {
     return automationTraceTemplatePaths[0];
   }
 
-  if (await fileExists(automationTraceTemplatePaths[1])) {
+  if (await fs.exists(automationTraceTemplatePaths[1])) {
     return automationTraceTemplatePaths[1];
   }
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "appium-xcode",
-  "description": "Description goes here.",
+  "description": "Interact with Xcode",
   "keywords": [
-    "appium"
+    "appium",
+    "ios",
+    "xcode"
   ],
   "version": "2.0.5",
   "author": "appium",
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/appium/appium-xcode.git"
@@ -23,14 +25,14 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-support": "^1.0.0",
+    "appium-logger": "^1.1.7",
+    "appium-support": "2.0.0-beta15",
     "asyncbox": "^2.0.2",
     "babel-runtime": "5.5.5",
-    "denodeify": "^1.2.1",
+    "bluebird": "^2.9.34",
+    "bplist-parser": "^0.1.0",
     "lodash": "^3.6.0",
-    "npmlog": "^1.2.0",
     "plist": "^1.1.0",
-    "q": "^1.2.0",
     "source-map-support": "^0.2.10",
     "teen_process": "^1.1.0"
   },
@@ -40,10 +42,11 @@
     "watch": "gulp"
   },
   "devDependencies": {
-    "appium-gulp-plugins": "^1.0.3",
+    "appium-gulp-plugins": "^1.3.0",
     "chai": "^2.2.0",
     "chai-as-promised": "^4.3.0",
     "gulp": "^3.8.10",
-    "mochawait": "^2.0.0"
+    "mochawait": "^2.0.0",
+    "sinon": "^1.15.4"
   }
 }


### PR DESCRIPTION
There are a number of places where we need information about the version and end up manipulating the string to get it. This adds a flag, `parse`, to the `getVersion` method in which case instead of getting `6.3.2`, you get

``` js
{
    versionString: '6.3.2',
    versionFloat: 6.3,
    major: 6,
    minor: 3,
    patch: 2
}
```
