### PR TITLE
Fix error handling

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -19,6 +19,19 @@ function hasExpectedSubDir (path) {
   return path.substring(path.length - XCODE_SUBDIR.length) === XCODE_SUBDIR;
 }
 
+async function runXcrunCommand (args, timeout = XCRUN_TIMEOUT) {
+  try {
+    return await exec('xcrun', args, {timeout});
+  } catch (err) {
+    // the true error can be hidden within the stderr
+    if (err.stderr) {
+      err.message = `${err.message}: ${err.stderr}`;
+    }
+
+    throw err;
+  }
+}
+
 async function getPathFromSymlink (failMessage) {
   // Node's invocation of xcode-select sometimes flakes and returns an empty string.
   // Not clear why. As a workaround, Appium can reliably deduce the version in use by checking
@@ -64,7 +77,6 @@ async function getPathFromSymlink (failMessage) {
   let msg = `Could not find path to Xcode by symlinks located in ${symlinkPath}, or ${legacySymlinkPath}`;
   log.warn(msg);
   throw new Error(msg);
-
 }
 
 async function getPathFromXcodeSelect (timeout = XCRUN_TIMEOUT) {
@@ -74,15 +86,14 @@ async function getPathFromXcodeSelect (timeout = XCRUN_TIMEOUT) {
   const xcodeFolderPath = stdout.replace(/\/$/, '').trim();
 
   if (!util.hasContent(xcodeFolderPath)) {
-    throw new Error("xcode-select returned an empty string");
+    log.errorAndThrow('xcode-select returned an empty string');
   }
 
   if (await fs.exists(xcodeFolderPath)) {
     return xcodeFolderPath;
   } else {
-    const msg = `xcode-select could not find xcode. Path: ${xcodeFolderPath} does not exist.`;
-    log.error(msg);
-    throw new Error(msg);
+    const msg = `xcode-select could not find xcode. Path '${xcodeFolderPath}' does not exist.`;
+    log.errorAndThrow(msg);
   }
 }
 
@@ -112,7 +123,7 @@ async function getVersionWithoutRetry (timeout = XCRUN_TIMEOUT) {
   // need to use string#match here; previous code used regexp#exec, which does not return null
   let match = version.match(versionPattern);
   if (match === null || !util.hasContent(match[0])) {
-    throw new Error(`Could not parse Xcode version. xcodebuild output was: ${version}`);
+    log.errorAndThrow(`Could not parse Xcode version. xcodebuild output was: ${version}`);
   }
 
   return match[0];
@@ -182,9 +193,8 @@ async function getMaxIOSSDKWithoutRetry (timeout = XCRUN_TIMEOUT) {
     return '6.1';
   }
 
-  const cmd = `xcrun`;
   const args = ['--sdk',  'iphonesimulator',  '--show-sdk-version'];
-  const {stdout} = await exec(cmd, args, {timeout});
+  const {stdout} = await runXcrunCommand(args, timeout);
 
   const sdkVersion = stdout.trim();
   const match = /\d.\d/.exec(stdout);
@@ -233,9 +243,8 @@ async function getConnectedDevices (timeout = XCRUN_TIMEOUT) {
 }
 
 async function getInstrumentsPathWithoutRetry (timeout = XCRUN_TIMEOUT) {
-  const cmd = 'xcrun';
   const args = ['-find', 'instruments'];
-  let {stdout} = await exec(cmd, args, {timeout});
+  let {stdout} = await runXcrunCommand(args, timeout);
 
   if (!stdout) {
     stdout = "";
@@ -244,7 +253,7 @@ async function getInstrumentsPathWithoutRetry (timeout = XCRUN_TIMEOUT) {
   let instrumentsPath = stdout.trim();
 
   if (!instrumentsPath) {
-    throw new Error(`Could not find path to instruments binary using "${cmd}"`);
+    throw new Error(`Could not find path to instruments binary using 'xcrun ${args.join(' ')}'`);
   }
 
   return instrumentsPath;

--- a/test/xcode-specs.js
+++ b/test/xcode-specs.js
@@ -11,9 +11,7 @@ let should = chai.should();
 chai.use(chaiAsPromised);
 
 describe('xcode @skip-linux', () => {
-
   it('should get the path to xcode executable', async function () {
-
     let path = await xcode.getPath();
     should.exist(path);
     await fs.exists(path);
@@ -66,7 +64,6 @@ describe('xcode @skip-linux', () => {
   });
 
   it('should clear the cache if asked to', async function () {
-
     xcode.clearInternalCache();
 
     let before = new Date();
@@ -76,16 +73,7 @@ describe('xcode @skip-linux', () => {
 
   });
 
-  it('should find the automation trace template', async () => {
-    let path = await xcode.getAutomationTraceTemplatePath();
-
-    should.exist(path);
-    await fs.exists(path).should.eventually.be.true;
-    let suffix = ".tracetemplate";
-    path.slice(-suffix.length).should.equal(suffix);
-  });
-
-  it('should get max iOS SDK version', async() => {
+  it('should get max iOS SDK version', async () => {
     let version = await xcode.getMaxIOSSDK();
 
     should.exist(version);
@@ -93,18 +81,35 @@ describe('xcode @skip-linux', () => {
     (parseFloat(version)-6.1).should.be.at.least(0);
   });
 
-  it('should get a list of iOS devices', async() => {
+  it('should get a list of iOS devices', async () => {
     let devices = await xcode.getConnectedDevices();
     should.exist(devices);
     (typeof devices).should.equal('object');
   });
 
-  it('should get the path to instruments binary', async() => {
+  it('should get the path to instruments binary', async () => {
     let instrumentsPath = await xcode.getInstrumentsPath();
 
     should.exist(instrumentsPath);
     (typeof instrumentsPath).should.equal('string');
     instrumentsPath.length.should.be.above(3);
     await fs.exists(instrumentsPath);
+  });
+
+  describe('ui automation', function () {
+    before(async function () {
+      let version = await xcode.getVersion(true);
+      if (version.major >= 8) {
+        this.skip();
+      }
+    });
+    it('should find the automation trace template', async () => {
+      let path = await xcode.getAutomationTraceTemplatePath();
+
+      should.exist(path);
+      await fs.exists(path).should.eventually.be.true;
+      let suffix = ".tracetemplate";
+      path.slice(-suffix.length).should.equal(suffix);
+    });
   });
 });


### PR DESCRIPTION
`xcrun` will throw an error but put the pertinent message in stderr and not the error message. So move it around a bit, to give more information on errors.

I think this might help the persistent complain about not being able to find the sdk version.
