### PR TITLE
Add function to get the cli tools version

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -153,6 +153,20 @@ async function getVersion (parse = false, retries = DEFAULT_NUMBER_OF_RETRIES, t
   };
 }
 
+async function getCommandLineToolsVersion () {
+  let stdout;
+  try {
+    stdout = (await exec('pkgutil', [`--pkg-info=com.apple.pkg.CLTools_Executables`])).stdout;
+  } catch (err) {
+    log.warn(`Failed to get command line tools version: ${err.message}.`);
+    stdout = (await exec('pkgutil', [`--pkg-info=com.apple.pkg.DeveloperToolsCLI`])).stdout;
+  }
+
+  // stdout should have a line like `version: 8.0.0.0.1.1472435881`
+  let match = /^version: (.+)$/m.exec(stdout); // https://regex101.com/r/HV3x4d/1
+  return match ? match[1] : undefined;
+}
+
 async function getAutomationTraceTemplatePathWithoutRetry (timeout = XCRUN_TIMEOUT) {
   const xcodePath = await getPath(timeout);
 
@@ -280,4 +294,5 @@ function clearInternalCache () {
 
 export default { getPath, getVersion, getAutomationTraceTemplatePath, getMaxIOSSDK,
          getAutomationTraceTemplatePathWithoutRetry, getMaxIOSSDKWithoutRetry,
-         getConnectedDevices, clearInternalCache, getInstrumentsPath };
+         getConnectedDevices, clearInternalCache, getInstrumentsPath,
+         getCommandLineToolsVersion };

--- a/test/xcode-specs.js
+++ b/test/xcode-specs.js
@@ -66,6 +66,11 @@ describe('xcode @skip-linux', function () {
     });
   });
 
+  it('should get the command line tools version', async () => {
+    let cliVersion = await xcode.getCommandLineToolsVersion();
+    _.isString(cliVersion).should.be.true;
+  });
+
   it('should clear the cache if asked to', async function () {
     xcode.clearInternalCache();
 


### PR DESCRIPTION
Trying to track down the differences in a system, it seemed to come down eventually to the command line tools. So get access to them so we can log them when we log the xcode version.