### PR TITLE
Use better logic to get CLI tools

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -156,12 +156,19 @@ async function getVersion (parse = false, retries = DEFAULT_NUMBER_OF_RETRIES, t
 async function getCommandLineToolsVersion () {
   let stdout;
   try {
-    stdout = (await exec('pkgutil', [`--pkg-info=com.apple.pkg.CLTools_Executables`])).stdout;
+    // first try to get the name of the correct package
+    let pkg = (await exec('pkgutil', ['--pkgs=com.apple.pkg.DevSDK_.*'])).stdout;
+    // now try to find the contents of the package
+    stdout = (await exec('pkgutil', [`--pkg-info=${pkg.trim()}`])).stdout;
   } catch (err) {
     try {
-      stdout = (await exec('pkgutil', [`--pkg-info=com.apple.pkg.DeveloperToolsCLI`])).stdout;
+      stdout = (await exec('pkgutil', [`--pkg-info=com.apple.pkg.CLTools_Executables`])).stdout;
     } catch (err) {
-      stdout = '';
+      try {
+        stdout = (await exec('pkgutil', [`--pkg-info=com.apple.pkg.DeveloperToolsCLI`])).stdout;
+      } catch (err) {
+        stdout = '';
+      }
     }
   }
 

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -154,21 +154,23 @@ async function getVersion (parse = false, retries = DEFAULT_NUMBER_OF_RETRIES, t
 }
 
 async function getCommandLineToolsVersion () {
+  // there are a number of different ways that the CLI tools version has been
+  // represented. Try them from most reliable to least, falling down the chain
+  const getVersionFunctions = [
+    async () => {
+      let pkg = (await exec('pkgutil', ['--pkgs=com.apple.pkg.DevSDK_.*'])).stdout;
+      return (await exec('pkgutil', [`--pkg-info=${pkg.trim()}`])).stdout;
+    },
+    async () => (await exec('pkgutil', [`--pkg-info=com.apple.pkg.CLTools_Executables`])).stdout,
+    async () => (await exec('pkgutil', [`--pkg-info=com.apple.pkg.DeveloperToolsCLI`])).stdout,
+  ];
   let stdout;
-  try {
-    // first try to get the name of the correct package
-    let pkg = (await exec('pkgutil', ['--pkgs=com.apple.pkg.DevSDK_.*'])).stdout;
-    // now try to find the contents of the package
-    stdout = (await exec('pkgutil', [`--pkg-info=${pkg.trim()}`])).stdout;
-  } catch (err) {
+  for (let getVersion of getVersionFunctions) {
     try {
-      stdout = (await exec('pkgutil', [`--pkg-info=com.apple.pkg.CLTools_Executables`])).stdout;
-    } catch (err) {
-      try {
-        stdout = (await exec('pkgutil', [`--pkg-info=com.apple.pkg.DeveloperToolsCLI`])).stdout;
-      } catch (err) {
-        stdout = '';
-      }
+      stdout = await getVersion();
+      break;
+    } catch (ign) {
+      stdout = '';
     }
   }
 

--- a/test/index-specs.js
+++ b/test/index-specs.js
@@ -5,8 +5,8 @@ import chai from 'chai';
 
 chai.should();
 
-describe('index', () => {
-  it('exported objects should exist', () => {
+describe('index', function () {
+  it('exported objects should exist', function () {
     xcode.should.exist;
   });
 });

--- a/test/xcode-specs.js
+++ b/test/xcode-specs.js
@@ -66,7 +66,7 @@ describe('xcode @skip-linux', function () {
     });
   });
 
-  it('should get the command line tools version', async () => {
+  it('should get the command line tools version', async function () {
     let cliVersion = await xcode.getCommandLineToolsVersion();
     _.isString(cliVersion).should.be.true;
   });
@@ -81,7 +81,7 @@ describe('xcode @skip-linux', function () {
 
   });
 
-  it('should get max iOS SDK version', async () => {
+  it('should get max iOS SDK version', async function () {
     let version = await xcode.getMaxIOSSDK();
 
     should.exist(version);
@@ -89,20 +89,20 @@ describe('xcode @skip-linux', function () {
     (parseFloat(version)-6.1).should.be.at.least(0);
   });
 
-  it('should get max tvOS SDK version', async () => {
+  it('should get max tvOS SDK version', async function () {
     let version = await xcode.getMaxTVOSSDK();
 
     should.exist(version);
     (typeof version).should.equal('string');
   });
 
-  it('should get a list of devices', async () => {
+  it('should get a list of devices', async function () {
     let devices = await xcode.getConnectedDevices();
     should.exist(devices);
     (typeof devices).should.equal('object');
   });
 
-  it('should get the path to instruments binary', async () => {
+  it('should get the path to instruments binary', async function () {
     let instrumentsPath = await xcode.getInstrumentsPath();
 
     should.exist(instrumentsPath);
@@ -118,7 +118,7 @@ describe('xcode @skip-linux', function () {
         this.skip();
       }
     });
-    it('should find the automation trace template', async () => {
+    it('should find the automation trace template', async function () {
       let path = await xcode.getAutomationTraceTemplatePath();
 
       should.exist(path);


### PR DESCRIPTION
The packages we look for are not always there, but there is always a `com.apple.pkg.DevSDK_.*` package. So figure out what that is and get it. Fall back on old way if something goes wrong.