### PR TITLE
Get rid of arrow functions in mocha aparatus

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,19 +42,20 @@
     "e2e-test": "gulp e2e-test",
     "coverage": "gulp coveralls",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
-    "lint": "gulp eslint"
+    "lint": "gulp eslint",
+    "lint:fix": "gulp eslint --fix"
   },
   "pre-commit": [
     "precommit-msg",
     "test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.1.4",
+    "appium-gulp-plugins": "^2.2.1",
     "babel-eslint": "^7.1.1",
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
     "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.0.1",
+    "eslint-config-appium": "^2.1.0",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-mocha": "^4.7.0",

--- a/test/xcode-specs.js
+++ b/test/xcode-specs.js
@@ -21,7 +21,7 @@ describe('xcode @skip-linux', function () {
 
   });
 
-  describe('getVersion', () => {
+  describe('getVersion', function () {
     let versionRE = /\d\.\d\.*\d*/;
 
     it('should get the version of xcode', async function () {


### PR DESCRIPTION
Add a gulp task for fixing eslint. And fix the arrow functions in mocha.

appium/appium#10016