### PR TITLE
Allow double digits in major version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ build
 *.log
 .idea
 coverage
-package-lock.json
+package-lock.json*

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -119,7 +119,7 @@ async function getVersionWithoutRetry (timeout = XCRUN_TIMEOUT) {
   let version = await plist.parsePlistFile(plistPath);
   version = version.CFBundleShortVersionString;
 
-  let versionPattern = /\d\.\d\.*\d*/;
+  let versionPattern = /\d+\.\d+\.*\d*/;
   // need to use string#match here; previous code used regexp#exec, which does not return null
   let match = version.match(versionPattern);
   if (match === null || !util.hasContent(match[0])) {

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -4,6 +4,7 @@ import { retry } from 'asyncbox';
 import _ from 'lodash';
 import { parse as parsePlistData } from 'plist';
 import { exec } from 'teen_process';
+import semver from 'semver';
 
 
 const env = process.env;
@@ -119,14 +120,15 @@ async function getVersionWithoutRetry (timeout = XCRUN_TIMEOUT) {
   let version = await plist.parsePlistFile(plistPath);
   version = version.CFBundleShortVersionString;
 
-  let versionPattern = /\d+\.\d+\.*\d*/;
-  // need to use string#match here; previous code used regexp#exec, which does not return null
-  let match = version.match(versionPattern);
-  if (match === null || !util.hasContent(match[0])) {
-    log.errorAndThrow(`Could not parse Xcode version. xcodebuild output was: ${version}`);
-  }
-
-  return match[0];
+  // let versionPattern = /\d+\.\d+\.*\d*/;
+  // // need to use string#match here; previous code used regexp#exec, which does not return null
+  // let match = version.match(versionPattern);
+  // if (match === null || !util.hasContent(match[0])) {
+  //   log.errorAndThrow(`Could not parse Xcode version. xcodebuild output was: ${version}`);
+  // }
+  //
+  // return match[0];
+  return semver.coerce(version);
 }
 
 const getVersionMemoized = _.memoize(
@@ -136,20 +138,20 @@ const getVersionMemoized = _.memoize(
 );
 
 async function getVersion (parse = false, retries = DEFAULT_NUMBER_OF_RETRIES, timeout = XCRUN_TIMEOUT) {
-  let version = await getVersionMemoized(retries, timeout);
+  const version = await getVersionMemoized(retries, timeout);
+  // xcode version strings are not exactly semver string: patch versions of 0
+  // are removed (e.g., '10.0.0' => '10.0')
+  const versionString = version.patch > 0 ? version.version : `${version.major}.${version.minor}`;
   if (!parse) {
-    return version;
+    return versionString;
   }
-  let match = /^(\d+)\.(\d+)(\.(\d+))?$/.exec(version);
-  // match should be an array, either of
-  //     [ '7.0', '7', '0', undefined, undefined, index: 0, input: '7.0' ]
-  //     [ '7.0.1', '7', '0', '.1', '1', index: 0, input: '7.0.1' ]
+
   return {
-    versionString: version,
-    versionFloat: parseFloat(`${match[1]}.${match[2]}`),
-    major: parseInt(match[1], 10),
-    minor: parseInt(match[2], 10),
-    patch: match[4] ? parseInt(match[4], 10) : undefined
+    versionString,
+    versionFloat: parseFloat(versionString),
+    major: version.major,
+    minor: version.minor,
+    patch: version.patch > 0 ? version.patch : undefined
   };
 }
 

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -107,7 +107,7 @@ const getPath = _.memoize(function (timeout = XCRUN_TIMEOUT) {
 
 
 async function getVersionWithoutRetry (timeout = XCRUN_TIMEOUT) {
-  let xcodePath = await getPath(timeout);
+  const xcodePath = await getPath(timeout);
 
   // we want to read the CFBundleShortVersionString from Xcode's plist.
   // It should be in /[root]/XCode.app/Contents/
@@ -117,18 +117,8 @@ async function getVersionWithoutRetry (timeout = XCRUN_TIMEOUT) {
     throw new Error(`Could not get Xcode version. ${plistPath} does not exist on disk.`);
   }
 
-  let version = await plist.parsePlistFile(plistPath);
-  version = version.CFBundleShortVersionString;
-
-  // let versionPattern = /\d+\.\d+\.*\d*/;
-  // // need to use string#match here; previous code used regexp#exec, which does not return null
-  // let match = version.match(versionPattern);
-  // if (match === null || !util.hasContent(match[0])) {
-  //   log.errorAndThrow(`Could not parse Xcode version. xcodebuild output was: ${version}`);
-  // }
-  //
-  // return match[0];
-  return semver.coerce(version);
+  const version = await plist.parsePlistFile(plistPath);
+  return semver.coerce(version.CFBundleShortVersionString);
 }
 
 const getVersionMemoized = _.memoize(

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-runtime": "=5.8.24",
     "lodash": "^4.17.4",
     "plist": "^3.0.1",
+    "semver": "^5.5.0",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.3.0"
   },


### PR DESCRIPTION
The first beta of Xcode 10 is out, and our regex doesn't allow for it.