### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-*.log
-coverage
-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,22 @@ matrix:
     - osx_image: xcode7.3
       node_js: "8"
     - osx_image: xcode7.3
-      node_js: "6"
+      node_js: "10"
 
     - osx_image: xcode8.3
       node_js: "8"
     - osx_image: xcode8.3
-      node_js: "6"
+      node_js: "10"
 
-    - osx_image: xcode9
+    - osx_image: xcode9.4
       node_js: "8"
-    - osx_image: xcode9
-      node_js: "6"
+    - osx_image: xcode9.4
+      node_js: "10"
+
+    - osx_image: xcode10
+      node_js: "8"
+    - osx_image: xcode10
+      node_js: "10"
 script:
   - _FORCE_LOGS=1 npm test
 after_success:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 // transpile:main
 
-import * as xcode from './lib/xcode';
+import xcode from './lib/xcode';
 
 export default xcode;

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -48,9 +48,9 @@ async function getPathFromSymlink (failMessage) {
   // xcode-select allows users to override its settings with the DEVELOPER_DIR env var,
   // so check that first
   if (util.hasContent(env.DEVELOPER_DIR)) {
-    const customPath = hasExpectedSubDir(env.DEVELOPER_DIR) ?
-                                         env.DEVELOPER_DIR  :
-                                         env.DEVELOPER_DIR + XCODE_SUBDIR;
+    const customPath = hasExpectedSubDir(env.DEVELOPER_DIR)
+      ? env.DEVELOPER_DIR
+      : env.DEVELOPER_DIR + XCODE_SUBDIR;
 
     if (await fs.exists(customPath)) {
       xcodePath = customPath;
@@ -211,7 +211,7 @@ async function getMaxIOSSDKWithoutRetry (timeout = XCRUN_TIMEOUT) {
     return '6.1';
   }
 
-  const args = ['--sdk',  'iphonesimulator',  '--show-sdk-version'];
+  const args = ['--sdk', 'iphonesimulator', '--show-sdk-version'];
   const {stdout} = await runXcrunCommand(args, timeout);
 
   const sdkVersion = stdout.trim();
@@ -231,7 +231,7 @@ const getMaxIOSSDK = _.memoize(
 );
 
 async function getMaxTVOSSDKWithoutRetry (timeout = XCRUN_TIMEOUT) {
-  const args = ['--sdk',  'appletvsimulator',  '--show-sdk-version'];
+  const args = ['--sdk', 'appletvsimulator', '--show-sdk-version'];
   const {stdout} = await runXcrunCommand(args, timeout);
 
   const sdkVersion = stdout.trim();
@@ -306,8 +306,10 @@ const getInstrumentsPath = _.memoize(
 function clearInternalCache () {
 
   // memoized functions
-  const memoized = [getPath, getVersionMemoized, getAutomationTraceTemplatePath,
-                    getMaxIOSSDK, getMaxTVOSSDK, getInstrumentsPath];
+  const memoized = [
+    getPath, getVersionMemoized, getAutomationTraceTemplatePath, getMaxIOSSDK,
+    getMaxTVOSSDK, getInstrumentsPath,
+  ];
 
   memoized.forEach((f) => {
     if (f.cache) {
@@ -316,7 +318,9 @@ function clearInternalCache () {
   });
 }
 
-export default { getPath, getVersion, getAutomationTraceTemplatePath, getMaxIOSSDK,
-         getAutomationTraceTemplatePathWithoutRetry, getMaxIOSSDKWithoutRetry,
-         getConnectedDevices, clearInternalCache, getInstrumentsPath,
-         getCommandLineToolsVersion, getMaxTVOSSDK, getMaxTVOSSDKWithoutRetry };
+export default {
+  getPath, getVersion, getAutomationTraceTemplatePath, getMaxIOSSDK,
+  getAutomationTraceTemplatePathWithoutRetry, getMaxIOSSDKWithoutRetry,
+  getConnectedDevices, clearInternalCache, getInstrumentsPath,
+  getCommandLineToolsVersion, getMaxTVOSSDK, getMaxTVOSSDKWithoutRetry,
+};

--- a/package.json
+++ b/package.json
@@ -59,15 +59,10 @@
   ],
   "devDependencies": {
     "ajv": "^6.5.3",
-    "appium-gulp-plugins": "^3.0.0",
-    "babel-eslint": "^9.0.0",
+    "appium-gulp-plugins": "^3.1.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^5.2.0",
-    "eslint-config-appium": "^3.0.0",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-mocha": "^5.1.0",
-    "eslint-plugin-promise": "^4.0.0",
+    "eslint-config-appium": "^3.1.0",
     "gulp": "^4.0.0",
     "mocha": "^5.1.1",
     "pre-commit": "^1.1.3"

--- a/package.json
+++ b/package.json
@@ -24,10 +24,16 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "lib",
+    "build/index.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-support": "^2.4.0",
     "asyncbox": "^2.3.0",
-    "babel-runtime": "=5.8.24",
     "lodash": "^4.17.4",
     "plist": "^3.0.1",
     "semver": "^5.5.0",
@@ -35,7 +41,8 @@
     "teen_process": "^1.3.0"
   },
   "scripts": {
-    "prepublish": "gulp prepublish",
+    "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",
     "mocha": "mocha",
@@ -51,31 +58,21 @@
     "test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.1",
-    "babel-eslint": "^7.1.1",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.0.0",
+    "babel-eslint": "^9.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.1.0",
-    "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.8.10",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.0.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-mocha": "^5.1.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "mocha": "^5.1.1",
     "pre-commit": "^1.1.3"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,9 +60,14 @@
   "devDependencies": {
     "ajv": "^6.5.3",
     "appium-gulp-plugins": "^3.1.0",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
+    "eslint": "^5.2.0",
     "eslint-config-appium": "^3.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
     "gulp": "^4.0.0",
     "mocha": "^5.1.1",
     "pre-commit": "^1.1.3"

--- a/test/xcode-specs.js
+++ b/test/xcode-specs.js
@@ -41,7 +41,7 @@ describe('xcode @skip-linux', function () {
 
       should.exist(path);
       await fs.exists(path);
-      (after-before).should.be.at.most(2);
+      (after - before).should.be.at.most(2);
 
       before = new Date();
       let version = await xcode.getVersion();
@@ -50,7 +50,7 @@ describe('xcode @skip-linux', function () {
       should.exist(version);
       _.isString(version).should.be.true;
       versionRE.test(version).should.be.true;
-      (after-before).should.be.at.most(2);
+      (after - before).should.be.at.most(2);
     });
 
     it('should get the parsed version', async function () {
@@ -77,8 +77,7 @@ describe('xcode @skip-linux', function () {
     let before = new Date();
     await xcode.getPath();
     let after = new Date();
-    (after-before).should.be.at.least(6);
-
+    (after - before).should.be.at.least(6);
   });
 
   it('should get max iOS SDK version', async function () {
@@ -86,7 +85,7 @@ describe('xcode @skip-linux', function () {
 
     should.exist(version);
     (typeof version).should.equal('string');
-    (parseFloat(version)-6.1).should.be.at.least(0);
+    (parseFloat(version) - 6.1).should.be.at.least(0);
   });
 
   it('should get max tvOS SDK version', async function () {


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.