### PR TITLE
Guess iOS version from Xcode verson on xcrun failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,12 @@
 os: osx
 language: node_js
+node_js: "8"
 matrix:
   include:
     - osx_image: xcode7.3
-      node_js: "8"
-    - osx_image: xcode7.3
-      node_js: "10"
-
     - osx_image: xcode8.3
-      node_js: "8"
-    - osx_image: xcode8.3
-      node_js: "10"
-
     - osx_image: xcode9.4
-      node_js: "8"
-    - osx_image: xcode9.4
-      node_js: "10"
-
-    - osx_image: xcode10
-      node_js: "8"
-    - osx_image: xcode10
-      node_js: "10"
+    - osx_image: xcode10.2
 script:
   - _FORCE_LOGS=1 npm test
 after_success:

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -233,7 +233,6 @@ async function getMaxIOSSDKFromXcodeVersion (timeout = XCRUN_TIMEOUT) {
   // as of now, the iOS version associated with an Xcode version is
   // just the Xcode version + 2
   return `${version.major + 2}.${version.minor}`;
-
 }
 
 const getMaxIOSSDK = _.memoize(

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -22,7 +22,11 @@ function hasExpectedSubDir (path) {
 
 async function runXcrunCommand (args, timeout = XCRUN_TIMEOUT) {
   try {
-    return await exec('xcrun', args, {timeout});
+    const res = await exec('xcrun', args, {timeout});
+    if (_.isUndefined(res)) {
+      throw new Error(`Nothing returned from trying to run 'xcrun ${args.join(' ')}'`);
+    }
+    return res;
   } catch (err) {
     // the true error can be hidden within the stderr
     if (err.stderr) {
@@ -224,9 +228,23 @@ async function getMaxIOSSDKWithoutRetry (timeout = XCRUN_TIMEOUT) {
   return sdkVersion;
 }
 
+async function getMaxIOSSDKFromXcodeVersion (timeout = XCRUN_TIMEOUT) {
+  const version = await getVersion(true, DEFAULT_NUMBER_OF_RETRIES, timeout);
+  // as of now, the iOS version associated with an Xcode version is
+  // just the Xcode version + 2
+  return `${version.major + 2}.${version.minor}`;
+
+}
+
 const getMaxIOSSDK = _.memoize(
   function getMaxIOSSDK (retries = DEFAULT_NUMBER_OF_RETRIES, timeout = XCRUN_TIMEOUT) {
-    return retry(retries, getMaxIOSSDKWithoutRetry, timeout);
+    try {
+      return retry(retries, getMaxIOSSDKWithoutRetry, timeout);
+    } catch (err) {
+      log.warn(`Unable to retrieve maximum iOS version: ${err.message}`);
+      log.warn('Guessing from Xcode version');
+      return getMaxIOSSDKFromXcodeVersion(timeout);
+    }
   }
 );
 


### PR DESCRIPTION
It appears that sometimes we get nothing from the `xcrun` call, and then things blow up trying to get the maximum iOS SDK version (error from @mykola-mokhnach):
```
TypeError: Cannot read property 'stdout' of undefined
   at stdout (/Users/elf/code/appium-ios-driver/node_modules/appium-xcode/lib/xcode.js:215:10)
   at Generator.next (<anonymous>)
   at asyncGeneratorStep (/Users/elf/code/appium-ios-driver/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
   at _next (/Users/elf/code/appium-ios-driver/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
```
This just gets the Xcode version (which seems to work, since we would get a similar, but different, `TypeError` otherwise, instead of the above) and guesses the iOS version.