### PR TITLE
Add a helper function to retrieve clang version

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const {
   getAutomationTraceTemplatePathWithoutRetry, getMaxIOSSDKWithoutRetry,
   getConnectedDevices, clearInternalCache, getInstrumentsPath,
   getCommandLineToolsVersion, getMaxTVOSSDK, getMaxTVOSSDKWithoutRetry,
+  getClangVersion,
 } = xcode;
 
 export {
@@ -15,5 +16,6 @@ export {
   getAutomationTraceTemplatePathWithoutRetry, getMaxIOSSDKWithoutRetry,
   getConnectedDevices, clearInternalCache, getInstrumentsPath,
   getCommandLineToolsVersion, getMaxTVOSSDK, getMaxTVOSSDKWithoutRetry,
+  getClangVersion,
 };
 export default xcode;

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -188,7 +188,7 @@ async function getClangVersion () {
     return null;
   }
   const {stdout} = await exec('clang', ['--version']);
-  const match = /clang\-([0-9\.]+)/.exec(stdout);
+  const match = /clang-([0-9.]+)/.exec(stdout);
   if (!match) {
     log.info(`Cannot parse clang version from ${stdout}`);
     return null;

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -171,6 +171,31 @@ async function getCommandLineToolsVersion () {
   return match ? match[1] : undefined;
 }
 
+/**
+ * Check https://trac.macports.org/wiki/XcodeVersionInfo
+ * to see the actual mapping between clang and other components.
+ *
+ * @returns {?string} The actual Clang version in x.x.x.x or x.x.x format,
+ * which is supplied with Command Line Tools. `null` is returned
+ * if CLT are not installed.
+ */
+async function getClangVersion () {
+  try {
+    await fs.which('clang');
+  } catch (e) {
+    log.info('Cannot find clang executable on the local system. ' +
+      'Are Xcode Command Line Tools installed?');
+    return null;
+  }
+  const {stdout} = await exec('clang', ['--version']);
+  const match = /clang\-([0-9\.]+)/.exec(stdout);
+  if (!match) {
+    log.info(`Cannot parse clang version from ${stdout}`);
+    return null;
+  }
+  return match[1];
+}
+
 async function getAutomationTraceTemplatePathWithoutRetry (timeout = XCRUN_TIMEOUT) {
   const xcodePath = await getPath(timeout);
 
@@ -323,4 +348,5 @@ export {
   getAutomationTraceTemplatePathWithoutRetry, getMaxIOSSDKWithoutRetry,
   getConnectedDevices, clearInternalCache, getInstrumentsPath,
   getCommandLineToolsVersion, getMaxTVOSSDK, getMaxTVOSSDKWithoutRetry,
+  getClangVersion,
 };

--- a/test/xcode-specs.js
+++ b/test/xcode-specs.js
@@ -3,7 +3,7 @@
 import xcode from '../index';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { fs } from 'appium-support';
+import { fs, util } from 'appium-support';
 import _ from 'lodash';
 
 
@@ -69,6 +69,11 @@ describe('xcode @skip-linux', function () {
   it('should get the command line tools version', async function () {
     let cliVersion = await xcode.getCommandLineToolsVersion();
     _.isString(cliVersion).should.be.true;
+  });
+
+  it('should get clang version', async function () {
+    const cliVersion = await xcode.getClangVersion();
+    _.isString(util.coerceVersion(cliVersion, true)).should.be.true;
   });
 
   it('should clear the cache if asked to', async function () {


### PR DESCRIPTION
The `getCommandLineToolsVersion` method is not very reliable and should be deprecated.