### PR TITLE
fix: Throw a proper error instance if xcode path detection fails

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -42,14 +42,12 @@ async function getPathFromXcodeSelect (timeout = XCRUN_TIMEOUT) {
   } catch (e) {
     const msg = `Cannot determine the path to Xcode by running 'xcode-select -p' command. ` +
     `Original error: ${e.stderr || e.message}`;
-    log.error(msg);
     throw new Error(msg);
   }
   // trim and remove trailing slash
   const developerRoot = String(stdout).replace(/\/$/, '').trim();
   if (!developerRoot) {
     const msg = await generateErrorMessage(`'xcode-select -p' returned an empty string`);
-    log.error(msg);
     throw new Error(msg);
   }
   // xcode-select might also return a path to command line tools
@@ -59,8 +57,7 @@ async function getPathFromXcodeSelect (timeout = XCRUN_TIMEOUT) {
   }
 
   const msg = await generateErrorMessage(`'${developerRoot}' is not a valid Xcode path`);
-  log.error(msg);
-  throw msg;
+  throw new Error(msg);
 }
 
 /**
@@ -77,9 +74,10 @@ async function getPathFromDeveloperDir () {
     return developerRoot;
   }
 
-  const msg = `The path to Xcode Developer dir '${developerRoot}' provided in DEVELOPER_DIR ` +
-  `environment variable is not a valid path`;
-  log.error(msg);
+  const msg = (
+    `The path to Xcode Developer dir '${developerRoot}' provided in DEVELOPER_DIR ` +
+    `environment variable is not a valid path`
+  );
   throw new Error(msg);
 }
 


### PR DESCRIPTION
Also removed confusing error logs. See https://github.com/appium/appium/issues/21646 for more details